### PR TITLE
Add runtime config for Telegram token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Telegram Bot
+
+This bot checks user subscriptions to specified Telegram groups and provides a small admin panel to manage those groups. When started it will ask for the bot token and a list of administrator user IDs.
+
+## Running
+
+```bash
+python bot.py
+```
+The program will request your Telegram bot token and admin IDs separated by commas.
+
+## Building an executable
+
+To create a standalone Windows executable you can use [PyInstaller](https://pyinstaller.org/):
+
+```bash
+pip install pyinstaller
+pyinstaller --onefile bot.py
+```
+
+The resulting `dist/bot.exe` will behave the same as running `python bot.py`.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,169 @@
+import json
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+# These will be populated at startup by asking the user for input
+TOKEN = None
+API_URL = None
+
+# Telegram user IDs that are allowed to edit groups.
+ADMIN_IDS: list[int] = []
+
+# List of group or channel IDs the user must be subscribed to by default
+REQUIRED_GROUPS = [
+    -1001234567890,  # replace with your group IDs
+    -1009876543210,
+]
+
+# Telegram user IDs that are allowed to edit groups will be
+# populated at runtime from user input.
+
+# File where group IDs are stored so that admins can edit them
+GROUPS_FILE = Path("groups.json")
+
+
+def load_groups() -> list[int]:
+    """Load required groups from disk or create the file with defaults."""
+    if GROUPS_FILE.exists():
+        try:
+            with GROUPS_FILE.open() as fh:
+                return json.load(fh)
+        except json.JSONDecodeError:
+            pass
+    GROUPS_FILE.write_text(json.dumps(REQUIRED_GROUPS))
+    return REQUIRED_GROUPS
+
+
+def save_groups(groups: list[int]):
+    GROUPS_FILE.write_text(json.dumps(groups))
+
+
+def configure():
+    """Ask the user for the bot token and admin IDs."""
+    global TOKEN, API_URL, ADMIN_IDS
+    if not TOKEN:
+        TOKEN = input("Введите токен Telegram бота: ").strip()
+    if not ADMIN_IDS:
+        ids = input(
+            "Введите ID администраторов через запятую: ").split(",")
+        ADMIN_IDS = [int(i.strip()) for i in ids if i.strip()]
+    API_URL = f"https://api.telegram.org/bot{TOKEN}/"
+
+
+required_groups = load_groups()
+
+
+def is_admin(user_id: int) -> bool:
+    """Check whether a user is allowed to manage groups."""
+    return user_id in ADMIN_IDS
+
+WELCOME_MSG = (
+    "Добро пожаловать! Подпишитесь на все наши каналы и группы, затем "
+    "отправьте команду /verify для проверки подписки."
+)
+ACCESS_GRANTED_MSG = "Подписка подтверждена. Доступ открыт!"
+ACCESS_DENIED_MSG = (
+    "Вы еще не подписались на все требуемые группы. Пожалуйста, проверьте "
+    "свои подписки и попробуйте снова."
+)
+
+
+def call_api(method: str, params: dict | None = None) -> dict:
+    data = urllib.parse.urlencode(params or {}).encode()
+    req = urllib.request.Request(API_URL + method, data=data)
+    with urllib.request.urlopen(req) as response:
+        return json.load(response)
+
+
+def get_updates(offset: int | None = None) -> list[dict]:
+    params = {"timeout": 100}
+    if offset:
+        params["offset"] = offset
+    resp = call_api("getUpdates", params)
+    return resp.get("result", [])
+
+
+def send_message(chat_id: int, text: str):
+    call_api("sendMessage", {"chat_id": chat_id, "text": text})
+
+
+def check_subscriptions(user_id: int) -> bool:
+    for group_id in required_groups:
+        member = call_api(
+            "getChatMember", {"chat_id": group_id, "user_id": user_id}
+        )
+        status = member.get("result", {}).get("status")
+        if status in {"left", "kicked"} or status is None:
+            return False
+    return True
+
+
+def handle_update(update: dict):
+    message = update.get("message")
+    if not message:
+        return
+    chat_id = message["chat"]["id"]
+    user_id = message["from"]["id"]
+    text = message.get("text", "")
+
+    if text.startswith("/start"):
+        send_message(chat_id, WELCOME_MSG)
+    elif text.startswith("/verify"):
+        if check_subscriptions(user_id):
+            send_message(chat_id, ACCESS_GRANTED_MSG)
+        else:
+            send_message(chat_id, ACCESS_DENIED_MSG)
+    elif text.startswith("/admin"):
+        if is_admin(user_id):
+            send_message(
+                chat_id,
+                "Команды: /groups, /addgroup <id>, /removegroup <id>",
+            )
+        else:
+            send_message(chat_id, "Нет доступа")
+    elif text.startswith("/groups"):
+        if is_admin(user_id):
+            groups_text = "\n".join(map(str, required_groups)) or "нет"
+            send_message(chat_id, f"Текущие группы:\n{groups_text}")
+        else:
+            send_message(chat_id, "Нет доступа")
+    elif text.startswith("/addgroup"):
+        if is_admin(user_id):
+            try:
+                group_id = int(text.split(maxsplit=1)[1])
+                if group_id not in required_groups:
+                    required_groups.append(group_id)
+                    save_groups(required_groups)
+                send_message(chat_id, "Группа добавлена")
+            except (IndexError, ValueError):
+                send_message(chat_id, "Использование: /addgroup <id>")
+        else:
+            send_message(chat_id, "Нет доступа")
+    elif text.startswith("/removegroup"):
+        if is_admin(user_id):
+            try:
+                group_id = int(text.split(maxsplit=1)[1])
+                if group_id in required_groups:
+                    required_groups.remove(group_id)
+                    save_groups(required_groups)
+                send_message(chat_id, "Группа удалена")
+            except (IndexError, ValueError):
+                send_message(chat_id, "Использование: /removegroup <id>")
+        else:
+            send_message(chat_id, "Нет доступа")
+
+
+if __name__ == "__main__":
+    configure()
+    offset = None
+    while True:
+        updates = get_updates(offset)
+        for upd in updates:
+            offset = upd["update_id"] + 1
+            try:
+                handle_update(upd)
+            except Exception as e:  # pragma: no cover - log the error
+                print("Error handling update", e)
+        time.sleep(1)


### PR DESCRIPTION
## Summary
- prompt for bot token and admin IDs at startup
- add README with usage instructions and info on creating an executable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843f1bdad888329987559a34f4ce662